### PR TITLE
Feature/build command

### DIFF
--- a/clojure/leiningen-plugin/project.clj
+++ b/clojure/leiningen-plugin/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.tengstrand/lein-polylith "0.0.27-alpha"
+(defproject polylith/lein-polylith "0.0.27-alpha"
   :description "Polylith - a tool for building component based architectures, by Joakim Tengstrand."
   :url "https://github.com/tengstrand/polylith"
   :license {:name "Eclipse Public License"

--- a/clojure/leiningen-plugin/src/leiningen/polylith.clj
+++ b/clojure/leiningen-plugin/src/leiningen/polylith.clj
@@ -8,6 +8,7 @@
             [leiningen.polylith.cmd.info :as info]
             [leiningen.polylith.cmd.settings :as settings]
             [leiningen.polylith.cmd.test :as test]
+            [leiningen.polylith.cmd.build :as build]
             [leiningen.polylith.file :as file]
             [clojure.string :as str]
             [leiningen.polylith.cmd.help :as help]))
@@ -51,4 +52,5 @@
          "info" (info/execute ws-path args)
          "settings" (settings/execute ws-path settings)
          "test" (test/execute ws-path ignored-tests sha1 sha2 args)
+         "build" (build/execute ws-path args)
          (println (str "Subtask '" subtask "' not found. Type 'lein polylith' for help.")))))))

--- a/clojure/leiningen-plugin/src/leiningen/polylith/cmd/build.clj
+++ b/clojure/leiningen-plugin/src/leiningen/polylith/cmd/build.clj
@@ -1,0 +1,76 @@
+(ns leiningen.polylith.cmd.build
+  (:require [leiningen.polylith.cmd.changes :as changes]
+            [clojure.java.shell :as shell]
+            [leiningen.polylith.cmd.help :as help]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(defn sh [& args]
+  (let [{:keys [exit out err]} (apply shell/sh args)]
+    (if (= 0 exit)
+      out
+      (throw (Exception. (str "Shell Err: " err " Exit code: " exit))))))
+
+(defn find-changes [ws-path last-success-sha1 current-sha1]
+  (let [changed-components   (changes/changes ws-path "c" last-success-sha1 current-sha1)
+        changed-builds       (changes/changes ws-path "b" last-success-sha1 current-sha1)
+        changed-systems      (changes/changes ws-path "s" last-success-sha1 current-sha1)]
+    (println)
+    (apply println "Changed components:" changed-components)
+    (apply println "Changed systems:" changed-systems)
+    (apply println "Changed builds:" changed-builds)
+    (println)
+    [changed-components changed-systems changed-builds]))
+
+(defn compile [ws-path dir changes]
+  (doseq [change changes]
+    (println "Compiling" (str dir "/" change))
+    (println (sh "lein" "install" :dir (str ws-path "/" dir "/" change)))))
+
+(defn compile-changes [ws-path components systems]
+  (when (< 0 (count components))
+    (println "Compiling apis")
+    (println (sh "lein" "install" :dir (str ws-path "/apis"))))
+  (compile ws-path "components" components)
+  (compile ws-path "systems" systems))
+
+(defn run-tests [ws-path changed-builds]
+  (doseq [build changed-builds]
+    (println "Testing" (str "builds/" build))
+    (println (sh "lein" "test" :dir (str ws-path "/builds/" build)))))
+
+(defn increment-version [ws-path build-number build]
+  (let [file (str ws-path "/builds/" build "/project.clj")
+        content (slurp file)
+        lines (str/split content #"\n")
+        first-line (first lines)
+        quotation-mark (.indexOf first-line "\"")
+        last-index (dec (count first-line))
+                   version (str/split (subs first-line (inc quotation-mark) last-index) #"\.")
+        new-version (str (inc (read-string (first version))) "." build-number)
+        new-first-line (str (subs first-line 0 quotation-mark) "\"" new-version "\"")
+        new-lines (into [new-first-line] (rest lines))
+        new-content (str/join "\n" new-lines)]
+    (spit file new-content)))
+
+(defn build [ws-path build-number changed-builds]
+  (doseq [build changed-builds]
+    (println "Building" (str "builds/" build))
+    (increment-version ws-path build-number build)
+    (if-not (.exists (io/file (str ws-path "/builds/" build "/build.sh")))
+      (println "Cannot find build script to run. Please add a build.sh to run under builds/" build " folder. Skipping build.")
+      (println (sh "./build.sh" :dir (str ws-path "/builds/" build))))))
+
+(defn execute [ws-path [last-success-sha1 current-sha1 build-number]]
+  (if (or (nil? current-sha1)
+          (nil? last-success-sha1)
+          (nil? build-number))
+    (do
+      (println "Missing parameters.")
+      (help/build))
+    (let [[changed-components
+           changed-systems
+           changed-builds] (find-changes ws-path last-success-sha1 current-sha1)]
+      (compile-changes ws-path changed-components changed-systems)
+      (run-tests ws-path changed-builds)
+      (build ws-path build-number changed-builds))))

--- a/clojure/leiningen-plugin/src/leiningen/polylith/cmd/help.clj
+++ b/clojure/leiningen-plugin/src/leiningen/polylith/cmd/help.clj
@@ -101,6 +101,16 @@
   (println "  example:")
   (println "    lein polylith diff" sha1 sha2))
 
+(defn build [sha1 sha2]
+  (println "  Compile, test, and build components, systems, builds between two Git hashes.")
+  (println "")
+  (println "  lein polylith build s1 s2")
+  (println "    s1 = last (successful) Git sha1")
+  (println "    s2 = current Git sha1")
+  (println)
+  (println "  example:")
+  (println "    lein polylith build" sha1 sha2))
+
 (defn info [sha1 sha2]
   (println "  Show the content of a Polylith system and optionally its changes")
   (println "  (each row is followed by an * if something is changed)")


### PR DESCRIPTION
Added a new command with name 'build'.

This new command gives plugin ability to find all changed components, systems, and builds, compile them, run tests inside builds, and finally run build scripts (build.sh files) within each build folder to make them ready to deploy.

After running 'lein polylith build sha1 sha2 build_number', you can deploy the final artifacts under each build folders target (builds/*/target). The script also updates the version number of each build. After a successful deployment, you can commit changes to git. 