### PR TITLE
Handle dashes correctly in directory names

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject polylith/lein-polylith "0.2.3"
+(defproject polylith/lein-polylith "0.2.4"
   :description "Polylith - a component based architecture, by Joakim Tengstrand."
   :url "https://github.com/tengstrand/lein-polylith"
   :license {:name "Eclipse Public License",

--- a/readme.md
+++ b/readme.md
@@ -54,10 +54,10 @@ The next thing to do is to add the Polylith plugin to `~/.lein/profiles.clj`. Af
 This ensures that the Polylith plugin can be called from anywhere in the file system and not just from the *workspace root* where the *project.clj* file with the Polylith declaration resides:
 ```clojure
 ...
-:plugins [[polylith/lein-polylith "0.2.3"]]
+:plugins [[polylith/lein-polylith "0.2.4"]]
 ```
 
-If called from the workspace root then it will use *0.2.3* in this case, otherwise it will use the latest version of the plugin.
+If called from the workspace root then it will use *0.2.4* in this case, otherwise it will use the latest version of the plugin.
 
 ### Latest version
 [![Clojars Project](https://clojars.org/polylith/lein-polylith/latest-version.svg)](http://clojars.org/polylith/lein-polylith)
@@ -160,7 +160,7 @@ The [Leiningen](https://leiningen.org) *project.clj* file defines which version 
 ```clojure
 (defproject se.example/example "1.0"
   :description "A Polylith workspace."
-  :plugins [[polylith/lein-polylith "0.2.3"]]
+  :plugins [[polylith/lein-polylith "0.2.4"]]
   :polylith {:top-namespace "se.example"
              :clojure-version "1.9.0"})
 ```
@@ -1494,7 +1494,7 @@ $ lein polylith
 ```
 
 ```
-  Polylith 0.2.3 (2020-05-09) - https://github.com/tengstrand/lein-polylith
+  Polylith 0.2.4 (2020-06-30) - https://github.com/tengstrand/lein-polylith
 
   lein polylith CMD [ARGS]  - where CMD [ARGS] are:
 

--- a/src/leiningen/polylith/cmd/create.clj
+++ b/src/leiningen/polylith/cmd/create.clj
@@ -47,7 +47,10 @@
     :else [false (str "Illegal first argument '" cmd "'")]))
 
 (defn ->dir [ws-ns]
-  (str/replace ws-ns #"\." "/"))
+  (->
+    ws-ns
+    (str/replace #"\." "/")
+    (str/replace #"-" "_")))
 
 (defn execute [ws-path top-dir top-ns clojure-version args]
   (let [skip-git? (contains? (set args) "-git")

--- a/src/leiningen/polylith/commands.clj
+++ b/src/leiningen/polylith/commands.clj
@@ -30,7 +30,9 @@
         settings (:polylith project)
         top-ns (:top-namespace settings "")
         github-url (:github-url settings "")
-        top-dir (str/replace top-ns #"\." "/")
+        top-dir (-> top-ns
+                    (str/replace #"\." "/")
+                    (str/replace #"-" "_"))
         clojure-version (:clojure-version settings "1.9.0")]
     (try
       (if (nil? settings)

--- a/src/leiningen/polylith/version.clj
+++ b/src/leiningen/polylith/version.clj
@@ -1,4 +1,4 @@
 (ns leiningen.polylith.version)
 
-(def version "0.2.3")
-(def date "2020-05-09")
+(def version "0.2.4")
+(def date "2020-06-30")

--- a/test/leiningen/polylith/cmd/create_system_test.clj
+++ b/test/leiningen/polylith/cmd/create_system_test.clj
@@ -64,32 +64,31 @@
 (deftest polylith-create--create-system--creates-system-with-namespace
   (with-redefs [file/current-path (fn [] @helper/root-dir)]
     (let [ws-dir  (str @helper/root-dir "/ws1")
-          project (helper/settings ws-dir "my.company")]
-      (helper/execute-polylith nil "create" "w" "ws1" "my.company" "-git")
+          project (helper/settings ws-dir "my.big-company")]
+      (helper/execute-polylith nil "create" "w" "ws1" "my.big-company" "-git")
       (helper/execute-polylith project "create" "s" "sys-1" "base-1")
 
       (is (= #{".gitignore"
                ".polylith"
                ".polylith/time.edn"
-               "readme.md"
                "bases"
                "bases/base-1"
-               "bases/base-1/readme.md"
                "bases/base-1/project.clj"
+               "bases/base-1/readme.md"
                "bases/base-1/resources"
                "bases/base-1/resources/.keep"
                "bases/base-1/resources/base-1"
                "bases/base-1/resources/base-1/.keep"
                "bases/base-1/src"
                "bases/base-1/src/my"
-               "bases/base-1/src/my/company"
-               "bases/base-1/src/my/company/base_1"
-               "bases/base-1/src/my/company/base_1/core.clj"
+               "bases/base-1/src/my/big_company"
+               "bases/base-1/src/my/big_company/base_1"
+               "bases/base-1/src/my/big_company/base_1/core.clj"
                "bases/base-1/test"
                "bases/base-1/test/my"
-               "bases/base-1/test/my/company"
-               "bases/base-1/test/my/company/base_1"
-               "bases/base-1/test/my/company/base_1/core_test.clj"
+               "bases/base-1/test/my/big_company"
+               "bases/base-1/test/my/big_company/base_1"
+               "bases/base-1/test/my/big_company/base_1/core_test.clj"
                "components"
                "environments"
                "environments/development"
@@ -98,7 +97,7 @@
                "environments/development/docs/sys-1-readme.md"
                "environments/development/interfaces"
                "environments/development/interfaces/my"
-               "environments/development/interfaces/my/company"
+               "environments/development/interfaces/my/big_company"
                "environments/development/project-files"
                "environments/development/project-files/bases"
                "environments/development/project-files/bases/base-1-project.clj"
@@ -114,77 +113,78 @@
                "environments/development/resources/base-1/.keep"
                "environments/development/src"
                "environments/development/src/my"
-               "environments/development/src/my/company"
-               "environments/development/src/my/company/base_1"
-               "environments/development/src/my/company/base_1/core.clj"
+               "environments/development/src/my/big_company"
+               "environments/development/src/my/big_company/base_1"
+               "environments/development/src/my/big_company/base_1/core.clj"
                "environments/development/test"
                "environments/development/test/my"
-               "environments/development/test/my/company"
-               "environments/development/test/my/company/base_1"
-               "environments/development/test/my/company/base_1/core_test.clj"
+               "environments/development/test/my/big_company"
+               "environments/development/test/my/big_company/base_1"
+               "environments/development/test/my/big_company/base_1/core_test.clj"
+               "images"
+               "images/logo.png"
                "interfaces"
                "interfaces/project.clj"
                "interfaces/src"
                "interfaces/src/my"
-               "interfaces/src/my/company"
-               "images"
-               "images/logo.png"
+               "interfaces/src/my/big_company"
                "project.clj"
+               "readme.md"
                "systems"
                "systems/sys-1"
-               "systems/sys-1/readme.md"
                "systems/sys-1/build.sh"
                "systems/sys-1/project.clj"
+               "systems/sys-1/readme.md"
                "systems/sys-1/resources"
                "systems/sys-1/resources/.keep"
                "systems/sys-1/resources/base-1"
                "systems/sys-1/resources/base-1/.keep"
                "systems/sys-1/src"
                "systems/sys-1/src/my"
-               "systems/sys-1/src/my/company"
-               "systems/sys-1/src/my/company/base_1"
-               "systems/sys-1/src/my/company/base_1/core.clj"}
+               "systems/sys-1/src/my/big_company"
+               "systems/sys-1/src/my/big_company/base_1"
+               "systems/sys-1/src/my/big_company/base_1/core.clj"}
              (set (file/relative-paths ws-dir))))
 
-      (is (= (helper/interfaces-project-content 'my.company/interfaces)
+      (is (= (helper/interfaces-project-content 'my.big-company/interfaces)
              (helper/content ws-dir "interfaces/project.clj")))
 
-      (is (= (helper/base-project-content "base-1" 'my.company/base-1 'my.company/interfaces)
+      (is (= (helper/base-project-content "base-1" 'my.big-company/base-1 'my.big-company/interfaces)
              (helper/content ws-dir "bases/base-1/project.clj")))
 
-      (is (= [['ns 'my.company.base-1.core
+      (is (= [['ns 'my.big-company.base-1.core
                [:gen-class]]
               ['defn '-main ['& 'args]
                ['println "Hello world!"]]]
-             (helper/content ws-dir "bases/base-1/src/my/company/base_1/core.clj")))
+             (helper/content ws-dir "bases/base-1/src/my/big_company/base_1/core.clj")))
 
-      (is (= [['ns 'my.company.base-1.core-test
+      (is (= [['ns 'my.big-company.base-1.core-test
                [:require ['clojure.test :refer :all]
-                ['my.company.base-1.core :as 'core]]]
+                ['my.big-company.base-1.core :as 'core]]]
               ['deftest 'hello-world-example-test
                ['let ['output ['with-out-str ['core/-main]]]
                 ['is
                  ['= "Hello world!\n"
                   'output]]]]]
-             (helper/content ws-dir "bases/base-1/test/my/company/base_1/core_test.clj")))
+             (helper/content ws-dir "bases/base-1/test/my/big_company/base_1/core_test.clj")))
 
-      (is (= [['defproject 'my.company/sys-1 "0.1"
+      (is (= [['defproject 'my.big-company/sys-1 "0.1"
                :description "A sys-1 system."
                :dependencies [['org.clojure/clojure "1.9.0"]]
                :aot :all
-               :main 'my.company.base-1.core]]
+               :main 'my.big-company.base-1.core]]
              (helper/content ws-dir "systems/sys-1/project.clj")))
 
-      (is (= [['defproject 'my.company/development "1.0"
+      (is (= [['defproject 'my.big-company/development "1.0"
                :description "The main development environment."
                :dependencies [['org.clojure/clojure "1.9.0"]]]]
              (helper/content ws-dir "environments/development/project.clj")))
 
-      (is (= [['defproject 'my.company/ws1 "1.0"
+      (is (= [['defproject 'my.big-company/ws1 "1.0"
                :description "A Polylith workspace."
                :plugins [['polylith/lein-polylith v/version]]
                :polylith {:clojure-version "1.9.0"
-                          :top-namespace   "my.company"}]]
+                          :top-namespace   "my.big-company"}]]
              (helper/content ws-dir "project.clj"))))))
 
 (deftest polylith-create--create-system--without-ns--creates-system

--- a/test/leiningen/polylith/cmd/create_workspace_test.clj
+++ b/test/leiningen/polylith/cmd/create_workspace_test.clj
@@ -48,58 +48,58 @@
 (deftest polylith-create--create-workspace--creates-a-workspace-with-namespace
   (with-redefs [file/current-path (fn [] @helper/root-dir)]
     (let [ws-dir         (str @helper/root-dir "/ws1")
-          _              (helper/execute-polylith nil "create" "w" "ws1" "my.company")
+          _              (helper/execute-polylith nil "create" "w" "ws1" "my.big-company")
           paths          (file/relative-paths ws-dir)
           filtered-paths (filter #(not (str/starts-with? (str %) ".git/")) paths)]
       (is (= #{".git"
                ".gitignore"
                ".polylith"
                ".polylith/time.edn"
-               "readme.md"
-               "images"
-               "images/logo.png"
-               "interfaces/src/my/company"
-               "interfaces/src/my"
-               "interfaces/src"
-               "interfaces/project.clj"
-               "interfaces"
-               "systems"
-               "components"
                "bases"
-               "environments/development/src/my/company"
-               "environments/development/src/my"
-               "environments/development/src"
-               "environments/development/interfaces/my/company"
-               "environments/development/interfaces/my"
-               "environments/development/interfaces"
+               "components"
+               "environments"
+               "environments/development"
                "environments/development/docs"
-               "environments/development/project-files/workspace-project.clj"
+               "environments/development/interfaces"
+               "environments/development/interfaces/my"
+               "environments/development/interfaces/my/big_company"
+               "environments/development/project-files"
+               "environments/development/project-files/bases"
+               "environments/development/project-files/components"
                "environments/development/project-files/interfaces-project.clj"
                "environments/development/project-files/systems"
-               "environments/development/project-files/components"
-               "environments/development/project-files/bases"
-               "environments/development/project-files"
+               "environments/development/project-files/workspace-project.clj"
+               "environments/development/project.clj"
                "environments/development/resources"
                "environments/development/resources/.keep"
-               "environments/development/test/my/company"
-               "environments/development/test/my"
+               "environments/development/src"
+               "environments/development/src/my"
+               "environments/development/src/my/big_company"
                "environments/development/test"
-               "environments/development/project.clj"
-               "environments/development"
-               "environments"
-               "project.clj"}
+               "environments/development/test/my"
+               "environments/development/test/my/big_company"
+               "images"
+               "images/logo.png"
+               "interfaces"
+               "interfaces/project.clj"
+               "interfaces/src"
+               "interfaces/src/my"
+               "interfaces/src/my/big_company"
+               "project.clj"
+               "readme.md"
+               "systems"}
              (set filtered-paths)))
 
-      (is (= (interfaces-project-content 'my.company/interfaces)
+      (is (= (interfaces-project-content 'my.big-company/interfaces)
              (helper/content ws-dir "interfaces/project.clj")))
 
-      (is (= (workspace-project-content 'my.company/ws1 "my.company")
+      (is (= (workspace-project-content 'my.big-company/ws1 "my.big-company")
              (helper/content ws-dir "environments/development/project-files/workspace-project.clj")))
 
-      (is (= (interfaces-project-content 'my.company/interfaces)
+      (is (= (interfaces-project-content 'my.big-company/interfaces)
              (helper/content ws-dir "environments/development/project-files/interfaces-project.clj")))
 
-      (is (= (development-project-content 'my.company/development)
+      (is (= (development-project-content 'my.big-company/development)
              (helper/content ws-dir "environments/development/project.clj")))
 
       (is (= gitignore-content


### PR DESCRIPTION
Fixes #42 

When a workspace or system is created, handle dashes (-) in the top namespace correctly by replacing them with underscore (_).